### PR TITLE
Add support for http-01 verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ Example Playbook
   roles:
       - role: ansible-docker-base
         vars:
+          server_cert: /etc/ssl/certs/server-chain.cert
+          server_cert_key: /etc/ssl/private/server.key
           sites:
             webserver:
               type: static

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,5 +5,9 @@
 server_cert: /etc/ssl/certs/server-chain.cert
 server_cert_key: /etc/ssl/private/server.key
 
+# Should the .well-known/acme-challenge directory point somewhere?
+enable_http01_challenge: false
+http01_challenge_path: /var/www/_letsencrypt
+
 # See the README for how to set this
 sites: []

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,9 @@
 ---
 # defaults file for ansible-docker-base
+
+# Location of TLS certificate used for server. Should be a wildcard/support all sites
+server_cert: /etc/ssl/certs/server-chain.cert
+server_cert_key: /etc/ssl/private/server.key
+
 # See the README for how to set this
 sites: []

--- a/templates/reverseproxy.conf.j2
+++ b/templates/reverseproxy.conf.j2
@@ -29,6 +29,13 @@ server {
     access_log /var/log/nginx/{{ site_domain }}.access.log;
     error_log  /var/log/nginx/{{ site_domain }}.error.log warn;
 
+{% if allow_insecure and enable_http01_challenge %}
+    # ACME-challenge
+    location ^~ /.well-known/acme-challenge/ {
+        root {{ http01_challenge_path }};
+    }
+{% endif %}
+
     # reverse proxy
     location / {
         proxy_pass {{ proxy_url }};
@@ -57,6 +64,13 @@ server {
     listen [::]:80 {% if use_by_default %}default_server{% endif %};
 
     server_name {{ site_domain }};
+
+{% if enable_http01_challenge %}
+    # ACME-challenge
+    location ^~ /.well-known/acme-challenge/ {
+        root {{ http01_challenge_path }};
+    }
+{% endif %}
 
     location / {
         return 301 https://{{ site_domain }}$request_uri;

--- a/templates/staticsite.conf.j2
+++ b/templates/staticsite.conf.j2
@@ -26,6 +26,13 @@ server {
     ssl_verify_client      optional;
 {% endif %}
 
+{% if allow_insecure and enable_http01_challenge %}
+    # ACME-challenge
+    location ^~ /.well-known/acme-challenge/ {
+        root {{ http01_challenge_path }};
+    }
+{% endif %}
+
     location / {
 {% if client_ca_cert %}
         if ($ssl_client_verify != SUCCESS) {
@@ -49,6 +56,13 @@ server {
     listen [::]:80 {% if use_by_default %}default_server{% endif %};
 
     server_name {{ site_domain }};
+
+{% if enable_http01_challenge %}
+    # ACME-challenge
+    location ^~ /.well-known/acme-challenge/ {
+        root {{ http01_challenge_path }};
+    }
+{% endif %}
 
     location / {
         return 301 https://{{ site_domain }}$request_uri;


### PR DESCRIPTION
Adds handling of the `/.well-known/acme-challenge` location to handle http-01 verification, behind a flag.