### PR TITLE
Add feature allowing CSP to be disabled 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@
 name: CI with Molecule
 "on":
   push:
+  pull_request:
   workflow_dispatch:
   # Build master every Tuesday at 7AM (schedule only applies to the master branch)
   schedule:

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ sites:
     allow_insecure: false # Set this to allow the site to serve unencrypted (caution, security risk!). Default: False
     client_ca_cert: /etc/ssl/certs/my-custom-ca.crt # Location of a CA cert that client certificates should be validated
                                                     # against - specifying makes client cert mandatory. Default: empty
+    disable_csp: false # Set to true to disable adding a default Content-Security-Policy header. Default: False
     # Any extra config lines to insert into this site's location block, although make sure you don't cause accidental
     # security risks (like this example!). Default: empty
     extra_config: |
@@ -44,6 +45,7 @@ sites:
                            # so the `Host` header should match the server name. However sometimes you'll want to
                            # transparently proxy to an external site, in which case you need `use_proxy_host: True`.
                            # Mostly this is useful for the unit tests!. Default: False
+    disable_csp: false # Set to true to disable adding a default Content-Security-Policy header. Default: False
     # Any extra config lines to insert into this site's location block, although make sure you don't cause accidental
     # security risks (like this example!). Default: empty
     extra_config: |

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -56,6 +56,7 @@
     use_proxy_host: "{{ item.use_proxy_host | default(False) }}"
     use_by_default: "{{ item.use_by_default | default(False) }}"
     allow_insecure: "{{ item.allow_insecure | default(False) }}"
+    disable_csp: "{{ item.disable_csp | default(False) }}"
     extra_config: "{{ item.extra_config | default(None) }}"
   loop: "{{ sites }}"
   loop_control:
@@ -75,6 +76,7 @@
     client_ca_cert: "{{ item.client_ca_cert | default(None) }}"
     use_by_default: "{{ item.use_by_default | default(False) }}"
     allow_insecure: "{{ item.allow_insecure | default(False) }}"
+    disable_csp: "{{ item.disable_csp | default(False) }}"
     extra_config: "{{ item.extra_config | default(None) }}"
   loop: "{{ sites }}"
   loop_control:

--- a/templates/nginxconfig.io/security.conf
+++ b/templates/nginxconfig.io/security.conf
@@ -3,7 +3,8 @@ add_header X-Frame-Options           "SAMEORIGIN" always;
 add_header X-XSS-Protection          "1; mode=block" always;
 add_header X-Content-Type-Options    "nosniff" always;
 add_header Referrer-Policy           "no-referrer-when-downgrade" always;
-add_header Content-Security-Policy   "default-src 'self' http: https: data: blob: 'unsafe-inline'" always;
+# Note this appears in the per-site config because it has to be disabled in some cases, e.g. Grafana
+# add_header Content-Security-Policy   "default-src 'self' http: https: data: blob: 'unsafe-inline'" always;
 add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
 
 # . files

--- a/templates/reverseproxy.conf.j2
+++ b/templates/reverseproxy.conf.j2
@@ -24,6 +24,10 @@ server {
 
     # security
     include nginxconfig.io/security.conf;
+{% if not disable_csp %}
+    # Note this appears here instead of security.conf because it has to be disabled in some cases, e.g. Grafana
+    add_header Content-Security-Policy   "default-src 'self' http: https: data: blob: 'unsafe-inline'" always;
+{% endif %}
 
     # logging
     access_log /var/log/nginx/{{ site_domain }}.access.log;

--- a/templates/staticsite.conf.j2
+++ b/templates/staticsite.conf.j2
@@ -18,6 +18,10 @@ server {
 
     # security
     include nginxconfig.io/security.conf;
+{% if not disable_csp %}
+    # Note this appears here instead of security.conf because it has to be disabled in some cases, e.g. Grafana
+    add_header Content-Security-Policy   "default-src 'self' http: https: data: blob: 'unsafe-inline'" always;
+{% endif %}
 
 {% if client_ca_cert %}
     # Client cert verification


### PR DESCRIPTION
Adds `disable_csp` option to turn of Content-Security-Policy headers, for some sites that need it (e.g. Grafana).